### PR TITLE
Updated deprecated `:environment`option

### DIFF
--- a/lib/mina/delayed_job/tasks.rb
+++ b/lib/mina/delayed_job/tasks.rb
@@ -9,7 +9,7 @@ set :shared_dirs, fetch(:shared_dirs, []).push(fetch(:delayed_job_pid_dir))
 
 namespace :delayed_job do
   desc 'Stop delayed_job'
-  task stop: :environment do
+  task stop: :remote_environment do
     comment 'Stop delayed_job'
     in_path(fetch(:current_path)) do
       command "RAILS_ENV='#{fetch(:rails_env)}' #{fetch(:delayed_job)} #{fetch(:delayed_job_additional_params)} stop --pid-dir='#{fetch(:shared_path)}/#{fetch(:delayed_job_pid_dir)}'"
@@ -17,7 +17,7 @@ namespace :delayed_job do
   end
 
   desc 'Start delayed_job'
-  task start: :environment do
+  task start: :remote_environment do
     comment 'Start delayed_job'
     in_path(fetch(:current_path)) do
       command "RAILS_ENV='#{fetch(:rails_env)}' #{fetch(:delayed_job)} #{fetch(:delayed_job_additional_params)} start -n #{fetch(:delayed_job_processes)} --pid-dir='#{fetch(:shared_path)}/#{fetch(:delayed_job_pid_dir)}'"
@@ -25,7 +25,7 @@ namespace :delayed_job do
   end
 
   desc 'Restart delayed_job'
-  task restart: :environment do
+  task restart: :remote_environment do
     comment 'Restart delayed_job'
     in_path(fetch(:current_path)) do
       command "RAILS_ENV='#{fetch(:rails_env)}' #{fetch(:delayed_job)} #{fetch(:delayed_job_additional_params)} restart -n #{fetch(:delayed_job_processes)} --pid-dir='#{fetch(:shared_path)}/#{fetch(:delayed_job_pid_dir)}'"
@@ -33,7 +33,7 @@ namespace :delayed_job do
   end
 
   desc 'delayed_job status'
-  task status: :environment do
+  task status: :remote_environment do
     comment 'Delayed job Status'
     in_path(fetch(:current_path)) do
       command "RAILS_ENV='#{fetch(:rails_env)}' #{fetch(:delayed_job)} #{fetch(:delayed_job_additional_params)} status --pid-dir='#{fetch(:shared_path)}/#{fetch(:delayed_job_pid_dir)}'"

--- a/lib/mina/delayed_job/tasks.rb
+++ b/lib/mina/delayed_job/tasks.rb
@@ -2,7 +2,7 @@ require 'mina/bundler'
 require 'mina/rails'
 
 set :delayed_job, 'bin/delayed_job'
-set :delayed_job_pid_dir, 'pids'
+set :delayed_job_pid_dir, 'shared/pids'
 set :delayed_job_processes, 1
 set :delayed_job_additional_params, ''
 set :shared_dirs, fetch(:shared_dirs, []).push(fetch(:delayed_job_pid_dir))


### PR DESCRIPTION
Removed a deprecation notice by using the new `remote_environment` option in mina